### PR TITLE
Prepare MCP servers for PyPI publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,29 +46,33 @@ Provides access to the ROBOKOP Knowledge Graph for querying biomedical relations
 
 Each MCP server is published as an independent package on PyPI.
 
-### Install from PyPI
+### Recommended: Use with uvx
+
+No installation needed! Use `uvx` to run the servers in isolated environments (see Configuration section below).
+
+### Install in a Virtual Environment
+
+If you prefer to install the packages:
 
 ```bash
-# Install name-resolver-mcp
+# Create and activate a virtual environment
+python -m venv mcp-env
+source mcp-env/bin/activate  # On Windows: mcp-env\Scripts\activate
+
+# Install desired servers
 pip install name-resolver-mcp
-
-# Install nodenormalizer-mcp
 pip install nodenormalizer-mcp
-
-# Install robokop-mcp
 pip install robokop-mcp
 ```
 
-### Install from Source
-
-If you want to install from source for development:
+### Install from Source for Development
 
 ```bash
 # Clone the repository
 git clone https://github.com/cbizon/RoboMCP.git
 cd RoboMCP
 
-# Install a specific server
+# Install a specific server in editable mode
 cd name-resolver-mcp
 pip install -e .
 ```
@@ -90,21 +94,73 @@ Add the servers to your Claude Desktop configuration file:
 **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
 **Windows**: `%APPDATA%/Claude/claude_desktop_config.json`
 
+#### Using uvx (Recommended)
+
+The easiest way to use these servers is with `uvx`, which runs them in isolated environments without installation:
+
 ```json
 {
   "mcpServers": {
     "name-resolver": {
-      "command": "name-resolver-mcp"
+      "command": "uvx",
+      "args": ["name-resolver-mcp"]
     },
     "nodenormalizer": {
-      "command": "nodenormalizer-mcp"
+      "command": "uvx",
+      "args": ["nodenormalizer-mcp"]
     },
     "robokop": {
-      "command": "robokop-mcp"
+      "command": "uvx",
+      "args": ["robokop-mcp"]
     }
   }
 }
 ```
+
+#### For Local Development
+
+When running from source, use the full uv command:
+
+```json
+{
+  "mcpServers": {
+    "name-resolver": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/RoboMCP/name-resolver-mcp",
+        "python",
+        "run_server.py"
+      ]
+    },
+    "nodenormalizer": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/RoboMCP/nodenormalizer-mcp",
+        "python",
+        "run_server.py"
+      ]
+    },
+    "robokop": {
+      "command": "uv",
+      "args": [
+        "run",
+        "--directory",
+        "/absolute/path/to/RoboMCP/robokop-mcp",
+        "python",
+        "run_server.py"
+      ]
+    }
+  }
+}
+```
+
+**Note**: Replace `/absolute/path/to/RoboMCP` with your actual path.
+
+#### Custom API Endpoints
 
 To use custom API endpoints, add environment variables:
 

--- a/name-resolver-mcp/README.md
+++ b/name-resolver-mcp/README.md
@@ -1,0 +1,23 @@
+# Name Resolver MCP
+
+MCP server for the Name Resolution Service - search and resolve biological entity names to standard identifiers.
+
+## Documentation
+
+For full documentation, installation instructions, and usage examples, see the main [RoboMCP repository](https://github.com/cbizon/RoboMCP).
+
+## Quick Start
+
+```bash
+# Run with uvx (no installation needed)
+uvx name-resolver-mcp
+```
+
+## Tools
+
+- `lookup` - Search for biological entities by name with filtering options
+- `synonyms` - Get all known synonyms for biological entity CURIEs
+
+## License
+
+MIT License - see the [main repository](https://github.com/cbizon/RoboMCP) for details.

--- a/nodenormalizer-mcp/README.md
+++ b/nodenormalizer-mcp/README.md
@@ -1,0 +1,22 @@
+# Node Normalizer MCP
+
+MCP server for the Node Normalization Service - normalize and conflate biological entity identifiers.
+
+## Documentation
+
+For full documentation, installation instructions, and usage examples, see the main [RoboMCP repository](https://github.com/cbizon/RoboMCP).
+
+## Quick Start
+
+```bash
+# Run with uvx (no installation needed)
+uvx nodenormalizer-mcp
+```
+
+## Tools
+
+- `get_normalized_nodes` - Normalize biological entity CURIEs and find equivalent identifiers
+
+## License
+
+MIT License - see the [main repository](https://github.com/cbizon/RoboMCP) for details.

--- a/nodenormalizer-mcp/pyproject.toml
+++ b/nodenormalizer-mcp/pyproject.toml
@@ -5,13 +5,32 @@ build-backend = "hatchling.build"
 [project]
 name = "nodenormalizer-mcp"
 version = "0.1.0"
-description = "MCP server for Node Normalization API"
-authors = [{name = "Claude", email = "claude@anthropic.com"}]
+description = "MCP server for Node Normalization Service - normalize and conflate biological entity identifiers"
+readme = "README.md"
+license = {text = "MIT"}
+authors = [{name = "Chris Bizon"}]
 requires-python = ">=3.10"
+keywords = ["mcp", "biomedical", "translator", "normalization", "bioinformatics"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
 dependencies = [
     "fastmcp>=0.1.0",
     "httpx>=0.24.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/cbizon/RoboMCP"
+Repository = "https://github.com/cbizon/RoboMCP"
+Issues = "https://github.com/cbizon/RoboMCP/issues"
 
 [project.scripts]
 nodenormalizer-mcp = "nodenormalizer_mcp.server:main"

--- a/robokop-mcp/README.md
+++ b/robokop-mcp/README.md
@@ -1,0 +1,25 @@
+# ROBOKOP MCP
+
+MCP server for the ROBOKOP Knowledge Graph - query biomedical knowledge graph for nodes, edges, and relationships.
+
+## Documentation
+
+For full documentation, installation instructions, and usage examples, see the main [RoboMCP repository](https://github.com/cbizon/RoboMCP).
+
+## Quick Start
+
+```bash
+# Run with uvx (no installation needed)
+uvx robokop-mcp
+```
+
+## Tools
+
+- `get_node` - Get information about a specific node by CURIE
+- `get_edges` - Get edges connected to a node with optional filtering
+- `get_edge_summary` - Get a summary of edge types connected to a node
+- `get_edges_between` - Find all edges connecting two nodes
+
+## License
+
+MIT License - see the [main repository](https://github.com/cbizon/RoboMCP) for details.


### PR DESCRIPTION
## Summary

This PR prepares all three MCP servers (name-resolver, nodenormalizer, robokop) for publication on PyPI as independent packages.

## Changes

### Environment Variable Configuration
- Added environment variable support for API endpoints with public defaults:
  - `NAME_RESOLVER_URL` (default: `https://name-resolution-sri.renci.org`)
  - `NODE_NORMALIZER_URL` (default: `https://nodenormalization-sri.renci.org`)
  - `ROBOKOP_URL` (default: `https://automat.renci.org/robokopkg`)

### Removed Local Paths
- Added `claude_config.json` to `.gitignore`
- Removed `claude_config.json` files from git tracking (files still exist locally for development)

### PyPI Package Metadata
All three `pyproject.toml` files updated with:
- Proper author information
- MIT license reference
- Project URLs (GitHub repository)
- Keywords and classifiers for discoverability
- README references

### Documentation
- Added individual README.md for each package pointing to main repository
- Updated main README with uvx usage (recommended approach)
- Documented virtual environment installation
- Provided Claude Desktop configuration examples for:
  - uvx usage (recommended)
  - Local development with uv
  - Custom API endpoints via environment variables
- Removed global installation recommendations

## Testing

- Verified servers run locally with `uv run python run_server.py`
- Confirmed existing local `claude_config.json` files still work for development

## Next Steps

After merge, packages can be built and published to PyPI:
```bash
cd name-resolver-mcp && uv build
cd ../nodenormalizer-mcp && uv build  
cd ../robokop-mcp && uv build
```